### PR TITLE
Add start script for client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite"
   },
   "dependencies": {
     "bootstrap": "^5.3.6",


### PR DESCRIPTION
## Summary
- add start script to client/package.json so root `npm run dev` works
- verify server and client launch together

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684590fabf9883268da50fe04c1e283d