### PR TITLE
Fix start script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ npm install
 npm install --prefix client
 ```
 
+Start only the API server (use this if you don't need the client running):
+
+```bash
+npm start
+```
+
 Run the tests:
 
 ```bash
@@ -23,6 +29,13 @@ Start the API server and React client concurrently:
 
 ```bash
 npm run dev
+```
+
+This runs both the backend and frontend together. If you only want to start the
+backend API server, run:
+
+```bash
+npm start
 ```
 
 The API server runs on `http://localhost:3001` and the React app runs on `http://localhost:5173`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "server": "nodemon server.js",
+    "start": "node server.js",
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "test": "jest"


### PR DESCRIPTION
## Summary
- add a `start` script for running the API server
- document `npm start` usage and clarify dev instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846088f546c83269c0e400122c59711