### PR TITLE
Document DB_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple web application for tracking paychecks and bills. The backend is an Exp
 
 ## Setup
 
-Install dependencies for both server and client:
+The project requires **Node.js 18 or newer**. Install dependencies for both server and client:
 
 ```bash
 npm install
@@ -15,6 +15,22 @@ Run the tests:
 
 ```bash
 npm test
+```
+
+## Database
+
+The server uses a SQLite database whose location is determined by the `DB_PATH`
+environment variable. If `DB_PATH` is not set, the database defaults to
+`bills.db` in the project root.
+
+The test suite runs with `process.env.DB_PATH=':memory:'` to create an
+in-memory database.
+
+To start the server with a custom database file you can set `DB_PATH` when
+launching the server (the same works for `npm run dev`):
+
+```bash
+DB_PATH=/tmp/my-bills.db node server.js
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  },
   "type": "commonjs",
   "dependencies": {
     "body-parser": "^2.2.0",


### PR DESCRIPTION
## Summary
- mention Node.js 18+ requirement in README
- add engines.node field in package.json
- clarify custom DB_PATH usage for dev server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845923c73e083268957b2088d26a779